### PR TITLE
Modeling Prior Estimator

### DIFF
--- a/songsuro/condition/prior_estimator.py
+++ b/songsuro/condition/prior_estimator.py
@@ -1,0 +1,21 @@
+from torch import nn
+
+
+class PriorEstimator(nn.Module):
+	def __init__(self, condition_embedding_dim: int, output_dim: int):
+		"""
+		PriorEstimator to predict the start latent from the condition
+
+		:param condition_embedding_dim: The dimension of the condition embedding.
+		:param output_dim: The output dimension.
+			It must be the same with the latent dimension in the diffusion model.
+		"""
+		super().__init__()
+		self.layer = nn.Linear(condition_embedding_dim, output_dim)
+
+	def forward(self, x):
+		# Input x will be (Batch, Embedding_dim, Length)
+		x = x.transpose(1, 2)
+		x = self.layer(x)
+		x = x.transpose(1, 2)  # Output x will be (Batch, output_dim, Length)
+		return x

--- a/songsuro/diffusion/model.py
+++ b/songsuro/diffusion/model.py
@@ -144,20 +144,19 @@ class Denoiser(nn.Module):
 			]
 		)
 		self.skip_projection = nn.Linear(channel_size, channel_size)
-		self.output_projection = nn.Linear(channel_size, channel_size // 2)
+		self.output_projection = nn.Linear(channel_size, channel_size)
 
-	def forward(self, previous_step, diffusion_step, prior, condition_embedding):
+	def forward(self, x, diffusion_step, condition_embedding):
 		"""
 		Forward pass of the denoiser in Latent Diffusion Model.
 
-		:param previous_step: Shape is (B, c/2, L)
+		:param x: Shape is (B, c, L)
+			Previous step or X_T with prior
 		:param diffusion_step: Int or float. The step number of the diffusion step.
-		:param prior: Shape is (B, c/2, L)
 		:param condition_embedding: The condition embedding from the conditioner Encoder.
 			Shape is (B, input_condition_dim, L).
-		:return:
+		:return: (B, c, L)
 		"""
-		x = torch.concat((previous_step, prior), dim=1)  # (B, C, L)
 		step_embedding = self.step_embedding(diffusion_step)  # (B, C)
 
 		skip = None

--- a/tests/songsuro/condition/test_prior_estimator.py
+++ b/tests/songsuro/condition/test_prior_estimator.py
@@ -1,0 +1,62 @@
+import pytest
+import torch
+from torch import nn
+
+# Import the PriorEstimator class or include it directly in your test file
+from songsuro.condition.prior_estimator import PriorEstimator
+
+condition_embedding_dim = 128
+output_dim = 64
+
+
+class TestPriorEstimator:
+	@pytest.fixture
+	def prior_estimator(self):
+		model = PriorEstimator(condition_embedding_dim, output_dim)
+		return model
+
+	def test_initialization(self, prior_estimator):
+		"""Test that the PriorEstimator initializes correctly."""
+		# Check that the layer is a Linear layer
+		assert isinstance(prior_estimator.layer, nn.Linear)
+		# Check that the layer has the correct dimensions
+		assert prior_estimator.layer.in_features == condition_embedding_dim
+		assert prior_estimator.layer.out_features == output_dim
+
+	def test_forward_pass(self, prior_estimator):
+		"""Test the forward pass of the PriorEstimator."""
+		batch_size = 8
+		sequence_length = 16
+
+		# Create a random input tensor with shape (batch_size, embedding_dim, length)
+		x = torch.randn(batch_size, condition_embedding_dim, sequence_length)
+		# Forward pass
+		output = prior_estimator(x)
+		# Check output shape
+		assert output.shape == (batch_size, output_dim, sequence_length)
+
+	def test_transpose_operations(self, prior_estimator):
+		"""Test that the transpose operations work correctly."""
+		batch_size = 4
+		sequence_length = 10
+
+		# Set weights to a fixed value for deterministic testing
+		with torch.no_grad():
+			prior_estimator.layer.weight.fill_(0.1)
+			prior_estimator.layer.bias.fill_(0.0)
+
+		# Create an input with recognizable values
+		x = torch.ones(batch_size, condition_embedding_dim, sequence_length)
+
+		# Forward pass
+		output = prior_estimator(x)
+
+		# Expected output after transpose, linear layer, and transpose back
+		# Linear layer with weight 0.1 and input of ones should give:
+		# 0condition_embedding_dim for each element (plus bias of 0)
+		expected_value = 0.1 * condition_embedding_dim
+
+		# Check if all values in the output are close to the expected value
+		assert torch.allclose(
+			output, torch.full_like(output, expected_value), rtol=1e-5
+		)

--- a/tests/songsuro/diffusion/test_model.py
+++ b/tests/songsuro/diffusion/test_model.py
@@ -166,13 +166,10 @@ def test_denoiser_forward(denoiser, batch_size):
 	channel_size = 256
 	diffusion_step = torch.Tensor([40])
 
-	previous_step = torch.randn(batch_size, channel_size // 2, seq_length)
-	prior = torch.randn(
-		batch_size, channel_size // 2, seq_length
-	)  # Need to check because I don't know well about prior
+	previous_step = torch.randn(batch_size, channel_size, seq_length)
 	condition_embedding = torch.randn(batch_size, 192, seq_length)
 
-	output = denoiser(previous_step, diffusion_step, prior, condition_embedding)
+	output = denoiser(previous_step, diffusion_step, condition_embedding)
 
-	assert output.shape == (batch_size, channel_size // 2, seq_length)
+	assert output.shape == (batch_size, channel_size, seq_length)
 	assert torch.isfinite(output).all()


### PR DESCRIPTION
close #16

The prior estimator is a single layer.
According to Grad-TTS code, it has to be (Batch, channel, length) shape.

The single layer will be transform the condition embedding dimension to the channel dimension.

The detailed Grad-TTS & PriorGrad method will be adapted in the `train.py`.

Lastly, the `prior` do not go to diffusion model's `Denoiser` directly so I deleted it in the modeling.